### PR TITLE
Use socketpair instead of pipe

### DIFF
--- a/docs/api/handlers/utils.rst
+++ b/docs/api/handlers/utils.rst
@@ -14,5 +14,5 @@ Public API
 Private API
 +++++++++++
 
-  .. autofunction:: create_pipe
+  .. autofunction:: create_socket_pair
   .. autofunction:: create_tcp_socket

--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -509,12 +509,12 @@ class KazooClient(object):
         self._queue.append((request, async_object))
 
         # wake the connection, guarding against a race with close()
-        write_pipe = self._connection._write_pipe
-        if write_pipe is None:
+        write_sock = self._connection._write_sock
+        if write_sock is None:
             async_object.set_exception(ConnectionClosedError(
                 "Connection has been closed"))
         try:
-            os.write(write_pipe, b'\0')
+            write_sock.send(b'\0')
         except:
             async_object.set_exception(ConnectionClosedError(
                 "Connection has been closed"))
@@ -584,7 +584,7 @@ class KazooClient(object):
 
         self._stopped.set()
         self._queue.append((CloseInstance, None))
-        os.write(self._connection._write_pipe, b'\0')
+        self._connection._write_sock.send(b'\0')
         self._safe_close()
 
     def restart(self):

--- a/kazoo/handlers/gevent.py
+++ b/kazoo/handlers/gevent.py
@@ -17,7 +17,8 @@ except ImportError:
 
 from kazoo.handlers.utils import (
     create_tcp_socket, create_tcp_connection,
-    atexit_register, atexit_unregister)
+    atexit_register, atexit_unregister,
+    create_socket_pair)
 
 _using_libevent = gevent.__version__.startswith('0.')
 
@@ -122,6 +123,9 @@ class SequentialGeventHandler(object):
 
     def create_connection(self, *args, **kwargs):
         return create_tcp_connection(socket, *args, **kwargs)
+
+    def socketpair(self, *args, **kwargs):
+        return create_socket_pair(socket)
 
     def event_object(self):
         """Create an appropriate Event object"""

--- a/kazoo/handlers/threading.py
+++ b/kazoo/handlers/threading.py
@@ -25,7 +25,8 @@ except ImportError:  # pragma: nocover
 
 from kazoo.handlers.utils import (
     create_tcp_socket, create_tcp_connection,
-    atexit_register, atexit_unregister)
+    atexit_register, atexit_unregister,
+    create_socket_pair)
 
 # sentinel objects
 _NONE = object()
@@ -254,6 +255,9 @@ class SequentialThreadingHandler(object):
 
     def create_connection(self, *args, **kwargs):
         return create_tcp_connection(socket, *args, **kwargs)
+
+    def socketpair(self, *args, **kwargs):
+        return create_socket_pair(socket)
 
     def event_object(self):
         """Create an appropriate Event object"""

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -6,9 +6,7 @@ try:
 except ImportError:  # pragma: nocover
     HAS_FNCTL = False
 import functools
-import os
 import atexit
-import socket
 import errno
 
 
@@ -24,30 +22,30 @@ def _set_default_tcpsock_options(module, sock):
     return sock
 
 
-def create_socket_pair(port=0):
+def create_socket_pair(module, port=0):
     """Create socket pair.
 
     If socket.socketpair isn't available, we emulate it.
     """
     # See if socketpair() is available.
-    have_socketpair = hasattr(socket, 'socketpair')
+    have_socketpair = hasattr(module, 'socketpair')
     if have_socketpair:
-        client_sock, srv_sock = socket.socketpair()
+        client_sock, srv_sock = module.socketpair()
         return client_sock, srv_sock
 
     # Create a non-blocking temporary server socket
-    temp_srv_sock = socket.socket()
+    temp_srv_sock = module.socket()
     temp_srv_sock.setblocking(False)
     temp_srv_sock.bind(('', port))
     port = temp_srv_sock.getsockname()[1]
     temp_srv_sock.listen(1)
 
     # Create non-blocking client socket
-    client_sock = socket.socket()
+    client_sock = module.socket()
     client_sock.setblocking(False)
     try:
         client_sock.connect(('localhost', port))
-    except socket.error as err:
+    except module.error as err:
         # EWOULDBLOCK is not an error, as the socket is non-blocking
         if err.errno != errno.EWOULDBLOCK:
             raise

--- a/kazoo/handlers/utils.py
+++ b/kazoo/handlers/utils.py
@@ -8,6 +8,8 @@ except ImportError:  # pragma: nocover
 import functools
 import os
 import atexit
+import socket
+import errno
 
 
 def _set_fd_cloexec(fd):
@@ -22,16 +24,43 @@ def _set_default_tcpsock_options(module, sock):
     return sock
 
 
-def create_pipe():
-    """Create a non-blocking read/write pipe.
+def create_socket_pair(port=0):
+    """Create socket pair.
+
+    If socket.socketpair isn't available, we emulate it.
     """
-    r, w = os.pipe()
-    if HAS_FNCTL:
-        fcntl.fcntl(r, fcntl.F_SETFL, os.O_NONBLOCK)
-        fcntl.fcntl(w, fcntl.F_SETFL, os.O_NONBLOCK)
-        _set_fd_cloexec(r)
-        _set_fd_cloexec(w)
-    return r, w
+    # See if socketpair() is available.
+    have_socketpair = hasattr(socket, 'socketpair')
+    if have_socketpair:
+        client_sock, srv_sock = socket.socketpair()
+        return client_sock, srv_sock
+
+    # Create a non-blocking temporary server socket
+    temp_srv_sock = socket.socket()
+    temp_srv_sock.setblocking(False)
+    temp_srv_sock.bind(('', port))
+    port = temp_srv_sock.getsockname()[1]
+    temp_srv_sock.listen(1)
+
+    # Create non-blocking client socket
+    client_sock = socket.socket()
+    client_sock.setblocking(False)
+    try:
+        client_sock.connect(('localhost', port))
+    except socket.error as err:
+        # EWOULDBLOCK is not an error, as the socket is non-blocking
+        if err.errno != errno.EWOULDBLOCK:
+            raise
+
+    # Use select to wait for connect() to succeed.
+    import select
+    timeout = 1
+    readable = select.select([temp_srv_sock], [], [], timeout)[0]
+    if temp_srv_sock not in readable:
+        raise Exception('Client socket not connected in {} second(s)'.format(timeout))
+    srv_sock, _ = temp_srv_sock.accept()
+
+    return client_sock, srv_sock
 
 
 def create_tcp_socket(module):

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -16,7 +16,6 @@ from kazoo.exceptions import (
     SessionExpiredError,
     NoNodeError
 )
-from kazoo.handlers.utils import create_socket_pair
 from kazoo.loggingsupport import BLATHER
 from kazoo.protocol.serialization import (
     Auth,
@@ -168,7 +167,7 @@ class ConnectionHandler(object):
     def start(self):
         """Start the connection up"""
         if self.connection_closed.is_set():
-            self._read_sock, self._write_sock = create_socket_pair()
+            self._read_sock, self._write_sock = self.handler.socketpair()
             self.connection_closed.clear()
         if self._connection_routine:
             raise Exception("Unable to start, connection routine already "

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -16,7 +16,7 @@ from kazoo.exceptions import (
     SessionExpiredError,
     NoNodeError
 )
-from kazoo.handlers.utils import create_pipe
+from kazoo.handlers.utils import create_socket_pair
 from kazoo.loggingsupport import BLATHER
 from kazoo.protocol.serialization import (
     Auth,
@@ -145,8 +145,8 @@ class ConnectionHandler(object):
         self.connection_stopped.set()
         self.ping_outstanding = client.handler.event_object()
 
-        self._read_pipe = None
-        self._write_pipe = None
+        self._read_sock = None
+        self._write_sock = None
 
         self._socket = None
         self._xid = None
@@ -168,7 +168,7 @@ class ConnectionHandler(object):
     def start(self):
         """Start the connection up"""
         if self.connection_closed.is_set():
-            self._read_pipe, self._write_pipe = create_pipe()
+            self._read_sock, self._write_sock = create_socket_pair()
             self.connection_closed.clear()
         if self._connection_routine:
             raise Exception("Unable to start, connection routine already "
@@ -191,12 +191,12 @@ class ConnectionHandler(object):
         if not self.connection_stopped.is_set():
             raise Exception("Cannot close connection until it is stopped")
         self.connection_closed.set()
-        wp, rp = self._write_pipe, self._read_pipe
-        self._write_pipe = self._read_pipe = None
-        if wp is not None:
-            os.close(wp)
-        if rp is not None:
-            os.close(rp)
+        ws, rs = self._write_sock, self._read_sock
+        self._write_sock = self._read_sock = None
+        if ws is not None:
+            ws.close()
+        if rs is not None:
+            rs.close()
 
     def _server_pinger(self):
         """Returns a server pinger iterable, that will ping the next
@@ -416,11 +416,11 @@ class ConnectionHandler(object):
         except IndexError:
             # Not actually something on the queue, this can occur if
             # something happens to cancel the request such that we
-            # don't clear the pipe below after sending
+            # don't clear the socket below after sending
             try:
                 # Clear possible inconsistence (no request in the queue
-                # but have data in the read pipe), which causes cpu to spin.
-                os.read(self._read_pipe, 1)
+                # but have data in the read socket), which causes cpu to spin.
+                self._read_sock.recv(1)
             except OSError:
                 pass
             return
@@ -441,7 +441,7 @@ class ConnectionHandler(object):
 
         self._submit(request, connect_timeout, xid)
         client._queue.popleft()
-        os.read(self._read_pipe, 1)
+        self._read_sock.recv(1)
         client._pending.append((request, async_object, xid))
 
     def _send_ping(self, connect_timeout):
@@ -520,7 +520,7 @@ class ConnectionHandler(object):
                 jitter_time = random.randint(0, 40) / 100.0
                 # Ensure our timeout is positive
                 timeout = max([read_timeout / 2.0 - jitter_time, jitter_time])
-                s = self.handler.select([self._socket, self._read_pipe],
+                s = self.handler.select([self._socket, self._read_sock],
                                         [], [], timeout)[0]
 
                 if not s:

--- a/kazoo/tests/test_client.py
+++ b/kazoo/tests/test_client.py
@@ -370,29 +370,29 @@ class TestConnection(KazooTestCase):
         client = self.client
         client.stop()
 
-        write_pipe = client._connection._write_pipe
+        write_sock = client._connection._write_sock
 
-        # close the connection to free the pipe
+        # close the connection to free the socket
         client.close()
-        eq_(client._connection._write_pipe, None)
+        eq_(client._connection._write_sock, None)
 
         # sneak in and patch client to simulate race between a thread
         # calling stop(); close() and one running a command
         oldstate = client._state
         client._state = KeeperState.CONNECTED
-        client._connection._write_pipe = write_pipe
+        client._connection._write_sock = write_sock
         try:
-            # simulate call made after write pipe is closed
+            # simulate call made after write socket is closed
             self.assertRaises(ConnectionClosedError, client.exists, '/')
 
-            # simualte call made after write pipe is set to None
-            client._connection._write_pipe = None
+            # simulate call made after write socket is set to None
+            client._connection._write_sock = None
             self.assertRaises(ConnectionClosedError, client.exists, '/')
 
         finally:
             # reset for teardown
             client._state = oldstate
-            client._connection._write_pipe = None
+            client._connection._write_sock = None
 
 
 class TestClient(KazooTestCase):

--- a/kazoo/tests/test_connection.py
+++ b/kazoo/tests/test_connection.py
@@ -43,7 +43,7 @@ class TestConnectionHandler(KazooTestCase):
     def test_bad_deserialization(self):
         async_object = self.client.handler.async_result()
         self.client._queue.append((Delete(self.client.chroot, -1), async_object))
-        os.write(self.client._connection._write_pipe, b'\0')
+        self.client._connection._write_sock.send(b'\0')
 
         @raises(ValueError)
         def testit():
@@ -184,63 +184,50 @@ class TestConnectionHandler(KazooTestCase):
         # should be able to restart
         self.client.start()
 
-    def test_connection_pipe(self):
+    def test_connection_sock(self):
         client = self.client
-        read_pipe = client._connection._read_pipe
-        write_pipe = client._connection._write_pipe
+        read_sock = client._connection._read_sock
+        write_sock = client._connection._write_sock
 
-        assert read_pipe is not None
-        assert write_pipe is not None
+        assert read_sock is not None
+        assert write_sock is not None
 
-        # stop client and pipe should not yet be closed
+        # stop client and socket should not yet be closed
         client.stop()
-        assert read_pipe is not None
-        assert write_pipe is not None
-        os.fstat(read_pipe)
-        os.fstat(write_pipe)
+        assert read_sock is not None
+        assert write_sock is not None
 
-        # close client, and pipes should be
+        read_sock.getsockname()
+        write_sock.getsockname()
+
+        # close client, and sockets should be closed
         client.close()
 
-        try:
-            os.fstat(read_pipe)
-        except OSError as e:
-            if not e.errno == errno.EBADF:
-                raise
-        else:
-            self.fail("Expected read_pipe to be closed")
+        # Todo check socket closing
 
-        try:
-            os.fstat(write_pipe)
-        except OSError as e:
-            if not e.errno == errno.EBADF:
-                raise
-        else:
-            self.fail("Expected write_pipe to be closed")
-
-        # start client back up. should get a new, valid pipe
+        # start client back up. should get a new, valid socket
         client.start()
-        read_pipe = client._connection._read_pipe
-        write_pipe = client._connection._write_pipe
+        read_sock = client._connection._read_sock
+        write_sock = client._connection._write_sock
 
-        assert read_pipe is not None
-        assert write_pipe is not None
-        os.fstat(read_pipe)
-        os.fstat(write_pipe)
+        assert read_sock is not None
+        assert write_sock is not None
+        read_sock.getsockname()
+        write_sock.getsockname()
 
-    def test_dirty_pipe(self):
+    def test_dirty_sock(self):
         client = self.client
-        read_pipe = client._connection._read_pipe
-        write_pipe = client._connection._write_pipe
+        read_sock = client._connection._read_sock
+        write_sock = client._connection._write_sock
 
-        # add a stray byte to the pipe and ensure that doesn't
+        # add a stray byte to the socket and ensure that doesn't
         # blow up client. simulates case where some error leaves
-        # a byte in the pipe which doesn't correspond to the
+        # a byte in the socket which doesn't correspond to the
         # request queue.
-        os.write(write_pipe, b'\0')
+        write_sock.send(b'\0')
 
-        # eventually this byte should disappear from pipe
-        wait(lambda: client.handler.select([read_pipe], [], [], 0)[0] == [])
+        # eventually this byte should disappear from socket
+        wait(lambda: client.handler.select([read_sock], [], [], 0)[0] == [])
 
 
 class TestConnectionDrop(KazooTestCase):


### PR DESCRIPTION
PIPE may cause reconnect issue when use TreeCache on a big tree(e.g. have 40000+ subtrees) , because `[Errno 11] Resource temporarily unavailable`.


Merge https://github.com/python-zk/kazoo/pull/243 and https://github.com/python-zk/kazoo/pull/263