### PR TITLE
Add lock protection when wake up socketpair

### DIFF
--- a/kazoo/client.py
+++ b/kazoo/client.py
@@ -514,8 +514,10 @@ class KazooClient(object):
             async_object.set_exception(ConnectionClosedError(
                 "Connection has been closed"))
         try:
-            write_sock.send(b'\0')
-        except:
+            with self._connection._lock_write_sock:
+                write_sock.send(b'\0')
+        except BaseException as e:
+            self.logger.info('Catch an error when wake-up socketpair: %s', e)
             async_object.set_exception(ConnectionClosedError(
                 "Connection has been closed"))
 

--- a/kazoo/protocol/connection.py
+++ b/kazoo/protocol/connection.py
@@ -146,6 +146,7 @@ class ConnectionHandler(object):
 
         self._read_sock = None
         self._write_sock = None
+        self._lock_write_sock = client.handler.lock_object()
 
         self._socket = None
         self._xid = None


### PR DESCRIPTION
Prevent it may raise "This socket is already used by another greenlet" error when run code in multi coroutines environment.